### PR TITLE
Update flake inputs enable arguments

### DIFF
--- a/falsisign/default.nix
+++ b/falsisign/default.nix
@@ -8,7 +8,7 @@ with pkgs; let
     name,
     prePostFixup ? "",
   }: let
-    fixedPath = "${lib.makeBinPath ([coreutils file ghostscript imagemagick] ++ lib.optionals (name == "falsisign") [pdftk])}";
+    fixedPath = "${lib.makeBinPath ([coreutils file ghostscript imagemagick poppler_utils] ++ lib.optionals (name == "falsisign") [pdftk])}";
   in
     stdenv.mkDerivation {
       pname = name;
@@ -16,7 +16,7 @@ with pkgs; let
 
       nativeBuildInputs = [makeWrapper];
 
-      buildInputs = [coreutils file ghostscript pdftk imagemagick];
+      buildInputs = [coreutils file ghostscript pdftk imagemagick poppler_utils];
 
       src = falsisign-src;
 

--- a/falsisign/default.nix
+++ b/falsisign/default.nix
@@ -1,21 +1,26 @@
-{ pkgs, falsisign-src, custom-rotation ? "seq .1 .1 .5" }:
-
-with pkgs;
-
-let
-  makeDerivation = { name, prePostFixup ? "" }:
-    let
-      fixedPath = "${lib.makeBinPath ([ coreutils file ghostscript imagemagick ] ++ lib.optionals (name == "falsisign") [ pdftk ])}";
-    in
+{
+  pkgs,
+  falsisign-src,
+  custom-rotation ? "seq .1 .1 .5",
+}:
+with pkgs; let
+  makeDerivation = {
+    name,
+    prePostFixup ? "",
+  }: let
+    fixedPath = "${lib.makeBinPath ([coreutils file ghostscript imagemagick] ++ lib.optionals (name == "falsisign") [pdftk])}";
+  in
     stdenv.mkDerivation {
       pname = name;
       version = "0.1.0";
 
-      nativeBuildInputs = [ makeWrapper ];
+      nativeBuildInputs = [makeWrapper];
 
-      buildInputs = [ coreutils file ghostscript pdftk imagemagick ];
+      buildInputs = [coreutils file ghostscript pdftk imagemagick];
 
       src = falsisign-src;
+
+      buildPhase = ":";
 
       installPhase = ''
         mkdir -p $out/bin
@@ -23,24 +28,25 @@ let
         chmod +x $out/bin/${name}
       '';
 
-      postFixup = prePostFixup + ''
-        # replace bash
-        substituteInPlace $out/bin/${name} --replace '#!/bin/bash' '#! ${bash}/bin/bash'
+      postFixup =
+        prePostFixup
+        + ''
+          # replace bash
+          substituteInPlace $out/bin/${name} --replace '#!/bin/bash' '#! ${bash}/bin/bash'
 
-        # fix path
-        wrapProgram $out/bin/${name} --prefix PATH : ${fixedPath}
-      '';
+          # fix path
+          wrapProgram $out/bin/${name} --prefix PATH : ${fixedPath}
+        '';
 
       meta = with lib; {
         homepage = "https://gitlab.com/edouardklein/falsisign";
         license = licenses.wtfpl;
         description = "Command-line tool to simulate a document print-sign-and-scan process. Save trees, ink, time, and stick it to the bureaucrats!";
-        maintainers = [ maintainers.gvolpe ];
+        maintainers = [maintainers.gvolpe];
         platforms = platforms.all;
       };
     };
-in
-{
+in {
   falsisign = makeDerivation {
     name = "falsisign";
     prePostFixup = ''

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "falsisign-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1643041243,
-        "narHash": "sha256-ue9aOC8boq4ikYS01GHtwi/0nZbU5LmFkVYzB+ODzSs=",
+        "lastModified": 1654087514,
+        "narHash": "sha256-veucqHfbN+ZBsrWAc65mqOncIHFQkwmhbAQLGWTZD08=",
         "owner": "edouardklein",
         "repo": "falsisign",
-        "rev": "6417c42f33ef056d180bcb59750667aeb413778e",
+        "rev": "3ff24f0ceaf8bb12d07902a24f8f90c8b24fea38",
         "type": "gitlab"
       },
       "original": {
@@ -19,11 +19,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1641205782,
-        "narHash": "sha256-4jY7RCWUoZ9cKD8co0/4tFARpWB+57+r1bLLvXNJliY=",
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "b7547d3eed6f32d06102ead8991ec52ab0a4f1a7",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
         "type": "github"
       },
       "original": {
@@ -33,12 +33,15 @@
       }
     },
     "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 1644229661,
-        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -49,11 +52,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1645013224,
-        "narHash": "sha256-b7OEC8vwzJv3rsz9pwnTX2LQDkeOWz2DbKypkVvNHXc=",
+        "lastModified": 1731890469,
+        "narHash": "sha256-D1FNZ70NmQEwNxpSSdTXCSklBH1z2isPR84J6DQrJGs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b66b39216b1fef2d8c33cc7a5c72d8da80b79970",
+        "rev": "5083ec887760adfe12af64830a66807423a859a7",
         "type": "github"
       },
       "original": {
@@ -69,6 +72,21 @@
         "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -2,34 +2,37 @@
   description = "Falsisign script derivation";
 
   inputs = {
-    nixpkgs.url = github:nixos/nixpkgs/nixpkgs-unstable;
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
     falsisign-src = {
-      url = gitlab:edouardklein/falsisign;
+      url = "gitlab:edouardklein/falsisign";
       flake = false;
     };
-    flake-utils.url = github:numtide/flake-utils;
+    flake-utils.url = "github:numtide/flake-utils";
     flake-compat = {
-      url = github:edolstra/flake-compat;
+      url = "github:edolstra/flake-compat";
       flake = false;
     };
   };
 
-  outputs = { self, nixpkgs, falsisign-src, flake-utils, ... }:
-    let
-      forSystem = system:
-        let
-          pkgs = nixpkgs.legacyPackages.${system};
-          drv = pkgs.callPackage ./falsisign {
-            inherit pkgs falsisign-src;
-          };
-        in
-		{
-		  packages = {
-            falsisign = drv.falsisign;
-			signdiv = drv.signdiv;
-          };
-          packages.default = drv.falsisign;
-        };
-    in
+  outputs = {
+    self,
+    nixpkgs,
+    falsisign-src,
+    flake-utils,
+    ...
+  }: let
+    forSystem = system: let
+      pkgs = nixpkgs.legacyPackages.${system};
+      drv = pkgs.callPackage ./falsisign {
+        inherit pkgs falsisign-src;
+      };
+    in {
+      packages = {
+        falsisign = drv.falsisign;
+        signdiv = drv.signdiv;
+      };
+      packages.default = drv.falsisign;
+    };
+  in
     flake-utils.lib.eachDefaultSystem forSystem;
 }


### PR DESCRIPTION
I was unable to pass flakes like `-x 10 -y 10` to signdiv to remove the red borders. This is fixed by updating the input. I raised everything to current versions and fixed the package by disabling the buildPhase which now tried to execute `./test.sh`